### PR TITLE
Issue: dateTimePickerLocalization prop is not working

### DIFF
--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -159,7 +159,7 @@ class MTableBody extends React.Component {
             icons={this.props.icons}
             key="key-add-row"
             mode="add"
-            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow }}
+            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow, dateTimePickerLocalization: this.props.localization.dateTimePickerLocalization }}
             options={this.props.options}
             isTreeData={this.props.isTreeData}
             detailPanel={this.props.detailPanel}
@@ -182,7 +182,7 @@ class MTableBody extends React.Component {
             icons={this.props.icons}
             key="key-add-row"
             mode="add"
-            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow }}
+            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow, dateTimePickerLocalization: this.props.localization.dateTimePickerLocalization }}
             options={this.props.options}
             isTreeData={this.props.isTreeData}
             detailPanel={this.props.detailPanel}

--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -95,7 +95,7 @@ export default class MTableEditRow extends React.Component {
                 key={columnDef.tableData.id}
                 columnDef={cellProps}
                 value={value}
-                locale={this.props.localization.dateTimePickerLocalization}
+                dateTimePickerLocalization={this.props.localization.dateTimePickerLocalization}
                 rowData={this.state.data}
                 onChange={value => {
                   const data = { ...this.state.data };


### PR DESCRIPTION
because a variable was not set correctly. In addtion
while adding new rows the prop was not propagated
to the datePicker component.

Solution: Fixed incorrect variable in m-table-edit-row. Fixed missing
propagation of dateTimePickerLocalization in m-table-body.

## Related Issue
Relate the Github issue with this PR using `#`

## Description
Simple words to describe the overall goals of the pull request's commits.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Impacted Areas in Application
List general components of the application that this PR will affect:

*

## Additional Notes
This is optional, feel free to follow your hearth and write here :)